### PR TITLE
#24 fix ongoing timer when navigation back on config screen

### DIFF
--- a/src/components/GameScreenHeader.vue
+++ b/src/components/GameScreenHeader.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+
+import {GameMode} from "@/store/game.ts";
+
+defineProps<{
+  level: number,
+  nickname: string,
+  gameMode: GameMode,
+  remainingTime?: number,
+  flipsRemaining?: number
+}>()
+</script>
+
+<template>
+  <div class="flex flex-col align-middle items-center p-4">
+    <h1 class="text-2xl font-semibold">
+      Level: {{ level }}
+    </h1>
+    <h2 class="text-lg font-semibold">
+      Nickname: {{ nickname }}
+    </h2>
+    <div
+      v-if="gameMode === GameMode.TIMER"
+      class="text-xl font-medium mt-2"
+    >
+      Time Remaining: {{ remainingTime }}s
+    </div>
+    <div
+      v-if="gameMode === GameMode.MAX_FLIPS"
+      class="text-xl font-medium mt-2"
+    >
+      Flips Remaining: {{ flipsRemaining }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/src/components/__tests__/getTopThreeScores.test.ts
+++ b/src/components/__tests__/getTopThreeScores.test.ts
@@ -1,20 +1,22 @@
-import { describe, it, expect } from 'vitest';
-import { getTopThreeScores } from '@/utils/getTopThreeScores.ts';
+import {describe, expect, it} from 'vitest';
+import {getTopThreeScores} from '@/utils/getTopThreeScores.ts';
+import {GameMode} from "@/store/game.ts";
+import {GameData} from "@/types/GameData.ts";
 
 describe('getTopThreeScores', () => {
   it('returns the top three scores sorted by level in descending order', () => {
-    const games = [
-      { nickname: 'John', gameMode: 'Flip Mode', level: 1 },
-      { nickname: 'Jane', gameMode: 'Time Mode', level: 2 },
-      { nickname: 'Jack', gameMode: 'Time Mode', level: 3 },
+    const games: GameData[] = [
+      { nickname: 'John', gameMode: GameMode.MAX_FLIPS, level: 1 },
+      { nickname: 'Jane', gameMode: GameMode.TIMER, level: 2 },
+      { nickname: 'Jack', gameMode: GameMode.TIMER, level: 3 },
     ];
 
     const result = getTopThreeScores(games);
 
     expect(result).toEqual([
-      { nickname: 'Jack', gameMode: 'Time Mode', level: 3 },
-      { nickname: 'Jane', gameMode: 'Time Mode', level: 2 },
-      { nickname: 'John', gameMode: 'Flip Mode', level: 1 },
+      { nickname: 'Jack', gameMode: 'timer', level: 3 },
+      { nickname: 'Jane', gameMode: 'timer', level: 2 },
+      { nickname: 'John', gameMode: 'maxFlips', level: 1 },
     ]);
   });
 
@@ -24,16 +26,16 @@ describe('getTopThreeScores', () => {
   });
 
   it('handles an input with fewer than three games', () => {
-    const games = [
-      { nickname: 'John', gameMode: 'Flip Mode', level: 1 },
-      { nickname: 'Jane', gameMode: 'Time Mode', level: 2 },
-    ];
+    const games: GameData[] = [
+        { nickname: 'John', gameMode: GameMode.MAX_FLIPS, level: 1 },
+        { nickname: 'Jane', gameMode: GameMode.TIMER, level: 2
+    }];
 
     const result = getTopThreeScores(games);
 
     expect(result).toEqual([
-      { nickname: 'Jane', gameMode: 'Time Mode', level: 2 },
-      { nickname: 'John', gameMode: 'Flip Mode', level: 1 },
+      { nickname: 'Jane', gameMode: 'timer', level: 2 },
+      { nickname: 'John', gameMode: 'maxFlips', level: 1 },
     ]);
   });
 

--- a/src/components/screens/GameScreen.vue
+++ b/src/components/screens/GameScreen.vue
@@ -5,13 +5,14 @@ import {ref, onMounted, onBeforeUnmount} from 'vue';
 import {DefaultGameModeValues, GameMode} from "@/store/game.ts";
 import ConfirmDialog from '@/components/ConfirmDialog.vue';
 import LevelCompleteDialog from "@/components/LevelCompleteDialog.vue";
+import GameScreenHeader from "@/components/GameScreenHeader.vue";
 
 const {
   level,
   cards,
   gameStore,
   handleClick,
-  timeRemaining,
+  remainingTime,
   flipsRemaining,
   startTimer,
   pauseTimer,
@@ -62,26 +63,13 @@ onBeforeUnmount(() => {
         }"
       />
     </div>
-    <div class="flex flex-col align-middle items-center p-4">
-      <h1 class="text-2xl font-semibold">
-        Level: {{ level }}
-      </h1>
-      <h2 class="text-lg font-semibold">
-        Nickname: {{ gameStore.nickname }}
-      </h2>
-      <div
-        v-if="gameStore.gameMode === GameMode.TIMER"
-        class="text-xl font-medium mt-2"
-      >
-        Time Remaining: {{ timeRemaining }}s
-      </div>
-      <div
-        v-if="gameStore.gameMode === GameMode.MAX_FLIPS"
-        class="text-xl font-medium mt-2"
-      >
-        Flips Remaining: {{ flipsRemaining }}
-      </div>
-    </div>
+    <GameScreenHeader
+      :level="level"
+      :nickname="gameStore.nickname"
+      :game-mode="gameStore.gameMode"
+      :remaining-time="remainingTime"
+      :flips-remaining="flipsRemaining"
+    />
     <div class="flex justify-center">
       <div
         class="grid"

--- a/src/composable/__tests__/useGameLogic.test.ts
+++ b/src/composable/__tests__/useGameLogic.test.ts
@@ -1,20 +1,37 @@
 import {describe, it, expect, beforeEach} from 'vitest';
-import {nextTick} from 'vue';
+import {defineComponent, nextTick} from 'vue';
 import {useGameLogic} from '@/composable/useGameLogic';
 import {Card} from "@/types/Card.ts";
 import {GameLogic} from "@/types/GameLogic.ts";
 import {GameMode} from "@/store/game.ts";
 import {createPinia, setActivePinia} from "pinia";
+import {mount, VueWrapper} from "@vue/test-utils";
 
 describe('useGameLogic', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let wrapper: VueWrapper<any>;
     let game: GameLogic;
+
     const baseTime = 2;
     const baseFlips = 4;
 
     beforeEach(() => {
         const pinia = createPinia();
         setActivePinia(pinia);
-        game = useGameLogic(baseTime, baseFlips);
+
+        // Define and mount a dummy component
+        const TestComponent = defineComponent({
+            setup() {
+                return { game: useGameLogic(baseTime, baseFlips) };
+            },
+            template: `<div />`,
+        });
+
+        wrapper = mount(TestComponent, {
+            global: { plugins: [pinia] },
+        });
+
+        game = wrapper.vm.game;
     });
 
     it('initializes with correct default values', () => {
@@ -113,18 +130,18 @@ describe('useGameLogic', () => {
         const initialFlips = game.flipsRemaining.value;
         game.advanceToNextLevel();
 
-        expect(game.flipsRemaining.value).toBe(initialFlips + 5);
+        expect(game.flipsRemaining.value).toBe(initialFlips + 3);
     });
 
     it('increases timer when advancing to the next level in TIMER mode', async () => {
         game.gameStore.gameMode = GameMode.TIMER;
         game.level.value = 1;
 
-        const initialTime = game.timeRemaining.value;
+        const initialTime = game.remainingTime.value;
         game.advanceToNextLevel();
 
         expect(game.level.value).toBe(2);
-        expect(game.timeRemaining.value).toBe(initialTime + 5);
+        expect(game.remainingTime.value).toBe(initialTime + 5);
     });
 
     async function completeLevel(game: GameLogic) {

--- a/src/composable/__tests__/useTimer.test.ts
+++ b/src/composable/__tests__/useTimer.test.ts
@@ -1,22 +1,40 @@
 import { vi, expect, it, describe, beforeEach, Mock} from 'vitest';
 import {useTimer} from '@/composable/useTimer';
 import {createPinia, setActivePinia} from "pinia";
+import {mount, VueWrapper} from "@vue/test-utils";
+import {defineComponent} from "vue";
 
 describe('useTimer', () => {
     let gameOverMock: Mock<() => void>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let wrapper: VueWrapper<any>;
     let timerHook: ReturnType<typeof useTimer>;
+
     const baseTime = 4;
 
     beforeEach(() => {
         const pinia = createPinia();
         setActivePinia(pinia);
-        vi.useFakeTimers();
-        gameOverMock = vi.fn();
-        timerHook = useTimer(baseTime, gameOverMock);
+
+        const TestComponent = defineComponent({
+            setup() {
+                vi.useFakeTimers();
+                gameOverMock = vi.fn();
+                return { timerHook: useTimer(baseTime, gameOverMock) };
+            },
+            template: `<div />`,
+        });
+
+        wrapper = mount(TestComponent, {
+            global: { plugins: [pinia] },
+        });
+
+        timerHook = wrapper.vm.timerHook;
     });
 
+
     it('should initialize with the correct time remaining', () => {
-        expect(timerHook.timeRemaining.value).toBe(baseTime);
+        expect(timerHook.remainingTime.value).toBe(baseTime);
     });
 
     it('should decrement time remaining every second', async () => {
@@ -24,7 +42,7 @@ describe('useTimer', () => {
 
         vi.advanceTimersByTime(3000);
 
-        expect(timerHook.timeRemaining.value).toBe(baseTime - 3);
+        expect(timerHook.remainingTime.value).toBe(baseTime - 3);
     });
 
     it('should pause the timer correctly', async () => {
@@ -33,10 +51,10 @@ describe('useTimer', () => {
 
         timerHook.pauseTimer();
 
-        const timeAfterPause = timerHook.timeRemaining.value;
+        const timeAfterPause = timerHook.remainingTime.value;
         vi.advanceTimersByTime(3000);
 
-        expect(timerHook.timeRemaining.value).toBe(timeAfterPause);
+        expect(timerHook.remainingTime.value).toBe(timeAfterPause);
     });
 
     it('should reset and restart the timer with new time when setRemainingTime is called', async () => {
@@ -44,9 +62,9 @@ describe('useTimer', () => {
         vi.advanceTimersByTime(5000);
 
         timerHook.setRemainingTime(20);
-        expect(timerHook.timeRemaining.value).toBe(20);
+        expect(timerHook.remainingTime.value).toBe(20);
 
         vi.advanceTimersByTime(5000);
-        expect(timerHook.timeRemaining.value).toBe(15);
+        expect(timerHook.remainingTime.value).toBe(15);
     });
 });

--- a/src/composable/useGameLogic.ts
+++ b/src/composable/useGameLogic.ts
@@ -12,7 +12,7 @@ export function useGameLogic(baseTime: number, baseFlips: number): GameLogic {
     const flippedCards = ref<Card[]>([]);
     const isLevelComplete = ref<boolean>(false);
 
-    const {timeRemaining, setRemainingTime, startTimer, pauseTimer, resumeTimer, resetTimer} = useTimer(baseTime, gameOver);
+    const {remainingTime, setRemainingTime, startTimer, pauseTimer, resumeTimer, resetTimer} = useTimer(baseTime, gameOver);
     const {flipsRemaining, reduceFlipsAndCheckGameOver} = useMaxFlips(baseFlips, gameOver);
 
     const gameStore = useGameStore();
@@ -66,7 +66,7 @@ export function useGameLogic(baseTime: number, baseFlips: number): GameLogic {
     }
 
     const increaseFlips = () => {
-        flipsRemaining.value = baseFlips + (level.value - 1) * 5;
+        flipsRemaining.value = baseFlips + (level.value - 1) * 3;
     };
 
     const advanceToNextLevel = () => {
@@ -141,7 +141,7 @@ export function useGameLogic(baseTime: number, baseFlips: number): GameLogic {
         startTimer,
         pauseTimer,
         resumeTimer,
-        timeRemaining,
+        remainingTime,
         flipsRemaining,
         isLevelComplete,
         advanceToNextLevel,

--- a/src/composable/useTimer.ts
+++ b/src/composable/useTimer.ts
@@ -1,7 +1,7 @@
 import {ref} from 'vue';
 
 export function useTimer(baseTime: number, gameOver: () => void) {
-    const timeRemaining = ref(baseTime);
+    const remainingTime = ref(baseTime);
     let timerInterval: ReturnType<typeof setInterval> | null = null;
 
     const startTimer = () => {
@@ -10,16 +10,16 @@ export function useTimer(baseTime: number, gameOver: () => void) {
         }
 
         timerInterval = setInterval(() => {
-            if (timeRemaining.value < 1) {
+            if (remainingTime.value < 1) {
                 gameOver();
             } else {
-                timeRemaining.value -= 1;
+                remainingTime.value -= 1;
             }
         }, 1000);
     };
 
     const setRemainingTime = (newTime: number) => {
-        timeRemaining.value = newTime;
+        remainingTime.value = newTime;
         startTimer();
     };
 
@@ -31,12 +31,12 @@ export function useTimer(baseTime: number, gameOver: () => void) {
     };
 
     const resumeTimer = () => {
-        if (!timerInterval && timeRemaining.value > 0) {
+        if (!timerInterval && remainingTime.value > 0) {
             timerInterval = setInterval(() => {
-                if (timeRemaining.value < 1) {
+                if (remainingTime.value < 1) {
                     gameOver();
                 } else {
-                    timeRemaining.value -= 1;
+                    remainingTime.value -= 1;
                 }
             }, 1000);
         }
@@ -47,11 +47,11 @@ export function useTimer(baseTime: number, gameOver: () => void) {
             clearInterval(timerInterval);
             timerInterval = null;
         }
-        timeRemaining.value = baseTime;
+        remainingTime.value = baseTime;
     };
 
     return {
-        timeRemaining,
+        remainingTime,
         startTimer,
         setRemainingTime,
         pauseTimer,

--- a/src/shim-vue.d.ts
+++ b/src/shim-vue.d.ts
@@ -1,3 +1,4 @@
+// fix TS error where vue files are not recognized in IntelliJ
 declare module '*.vue' {
     import { defineComponent } from 'vue'
     const component: ReturnType<typeof defineComponent>

--- a/src/types/GameData.ts
+++ b/src/types/GameData.ts
@@ -1,5 +1,7 @@
+import {GameMode} from "@/store/game.ts";
+
 export type GameData = {
   nickname: string;
-  gameMode: string;
+  gameMode: GameMode;
   level: number;
 };

--- a/src/types/GameLogic.ts
+++ b/src/types/GameLogic.ts
@@ -7,7 +7,7 @@ export type GameLogic = {
     cards: Ref<Card[]>;
     flippedCards: Ref<Card[]>;
     gameStore: GameData;
-    timeRemaining: Ref<number>;
+    remainingTime: Ref<number>;
     flipsRemaining: Ref<number>;
     pauseTimer: () => void;
     resumeTimer: () => void;


### PR DESCRIPTION
### Issue
Before when navigating to the game, going back to config screen using the browser navigation and then going back to the game, the timer continued to count down and caused an alert. 
### Fix
This was fixed by resetting the time interval `onUnmounted`. Using `onUnmounted` required adapting the tests.

fixes #24 
